### PR TITLE
Make tests compatible with `Chameleon` 4.3+

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ CHANGES
 4.1 (unreleased)
 ================
 
-- Nothing changed yet.
+- Make tests compatible with ``Chameleon`` 4.3+, thus requiring at lest version
+  4.3.
 
 
 4.0 (2023-02-09)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ version = '4.1.dev0'
 
 
 install_requires = [
-    'Chameleon >= 2.10',
+    'Chameleon >= 4.3',
     'grokcore.component',
     'grokcore.view',
     'setuptools',

--- a/src/grokcore/chameleon/README.rst
+++ b/src/grokcore/chameleon/README.rst
@@ -203,7 +203,7 @@ and render it:
     This template knows about the following vars:
     <BLANKLINE>
       template (the template instance):
-       &lt;PageTemplateFile ...vars.cpt&gt;
+       &lt;PageTemplateFile ...vars.cpt'&gt;
     <BLANKLINE>
       view (the associated view):
        &lt;grokcore.chameleon.tests.cpt_fixture.app.Vars object at 0x...&gt;


### PR DESCRIPTION
Thus requiring at lest version 4.3.

That release broke the tests, see https://github.com/zopefoundation/grokcore.chameleon/actions/runs/7157615751