### PR TITLE
Do not allow Chameleon 4.3 as tests are not compatible with this version.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ CHANGES
 4.1 (unreleased)
 ================
 
-- Make tests compatible with ``Chameleon`` 4.3+, thus requiring at lest version
-  4.3.
+- The tests are not compatible with (yanked) ``Chameleon`` 4.3.0, thus not
+  allowing to use this version.
 
 
 4.0 (2023-02-09)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ version = '4.1.dev0'
 
 
 install_requires = [
-    'Chameleon >= 4.3',
+    'Chameleon != 4.3',
     'grokcore.component',
     'grokcore.view',
     'setuptools',

--- a/src/grokcore/chameleon/README.rst
+++ b/src/grokcore/chameleon/README.rst
@@ -203,7 +203,7 @@ and render it:
     This template knows about the following vars:
     <BLANKLINE>
       template (the template instance):
-       &lt;PageTemplateFile ...vars.cpt'&gt;
+       &lt;PageTemplateFile ...vars.cpt&gt;
     <BLANKLINE>
       view (the associated view):
        &lt;grokcore.chameleon.tests.cpt_fixture.app.Vars object at 0x...&gt;


### PR DESCRIPTION
Undoing the change from https://github.com/zopefoundation/grokcore.chameleon/pull/7 which are only valid for 4.3 which is yanked now.