### PR TITLE
Update translation handling to be compatible with Chameleon 4.3+

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ CHANGES
   allowing to use this version.
 
 - Update translation handling to be compatible with Chameleon 4.3+: do not
-  break no unhashable message ids, just return them.
+  break on unhashable message ids, just return them.
 
 
 4.0 (2023-02-09)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,8 +7,8 @@ CHANGES
 - The tests are not compatible with (yanked) ``Chameleon`` 4.3.0, thus not
   allowing to use this version.
 
-- Update translation handling to be compatible with Chameleon 4.3+: Only
-  translate message ids.
+- Update translation handling to be compatible with Chameleon 4.3+: do not
+  break no unhashable message ids, just return them.
 
 
 4.0 (2023-02-09)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ CHANGES
 - The tests are not compatible with (yanked) ``Chameleon`` 4.3.0, thus not
   allowing to use this version.
 
+- Update translation handling to be compatible with Chameleon 4.3+: Only
+  translate message ids.
+
 
 4.0 (2023-02-09)
 ================

--- a/src/grokcore/chameleon/README.rst
+++ b/src/grokcore/chameleon/README.rst
@@ -386,7 +386,7 @@ Translation
     </body>
     </html>
 
-Unhashable types might be used as message ids: The do not break, but do not get
+Unhashable types might be used as message ids: They do not break, but do not get
 translated either.
 
     >>> # What's for food today in Germany?

--- a/src/grokcore/chameleon/README.rst
+++ b/src/grokcore/chameleon/README.rst
@@ -381,7 +381,7 @@ Translation
       <h1>Menu</h1>
       <ol>
         <li>Deepfried breaded veal cutlets</li>
-        <li>Variants: ['none']</li>
+        <li>Variants: ['raw', 'bloody']</li>
       </ol>
     </body>
     </html>
@@ -400,7 +400,7 @@ translated either.
       <h1>Menu</h1>
       <ol>
         <li>Schnitzel</li>
-        <li>Variants: ['none']</li>
+        <li>Variants: ['raw', 'bloody']</li>
       </ol>
     </body>
     </html>

--- a/src/grokcore/chameleon/README.rst
+++ b/src/grokcore/chameleon/README.rst
@@ -381,9 +381,13 @@ Translation
       <h1>Menu</h1>
       <ol>
         <li>Deepfried breaded veal cutlets</li>
+        <li>Variants: ['none']</li>
       </ol>
     </body>
     </html>
+
+Unhashable types might be used as message ids: The do not break, but do not get
+translated either.
 
     >>> # What's for food today in Germany?
     >>> # We need to monkey patch the language settings for this test.
@@ -396,6 +400,7 @@ Translation
       <h1>Menu</h1>
       <ol>
         <li>Schnitzel</li>
+        <li>Variants: ['none']</li>
       </ol>
     </body>
     </html>

--- a/src/grokcore/chameleon/components.py
+++ b/src/grokcore/chameleon/components.py
@@ -15,6 +15,7 @@
 
 import os
 import sys
+import typing
 
 import chameleon.i18n
 import martian
@@ -67,7 +68,7 @@ class PageTemplate(PageTemplate):
                     target_language=None, default=None):
                 # We swap context with the request, that is required for
                 # zope.i18n.translate.
-                if isinstance(msgid, str):
+                if isinstance(msgid, typing.Hashable):
                     return zope.i18n.translate(
                         msgid, domain, mapping, request, target_language,
                         default)

--- a/src/grokcore/chameleon/components.py
+++ b/src/grokcore/chameleon/components.py
@@ -19,6 +19,7 @@ import sys
 import chameleon.i18n
 import martian
 import zope.i18n
+import zope.i18nmessageid
 from chameleon.tales import ExistsExpr
 from chameleon.tales import ImportExpr
 from chameleon.tales import NotExpr
@@ -67,8 +68,11 @@ class PageTemplate(PageTemplate):
                     target_language=None, default=None):
                 # We swap context with the request, that is required for
                 # zope.i18ntranslate.
-                return zope.i18n.translate(
-                    msgid, domain, mapping, request, target_language, default)
+                if isinstance(msgid, zope.i18nmessageid.Message):
+                    return zope.i18n.translate(
+                        msgid, domain, mapping, request, target_language,
+                        default)
+                return msgid
 
             vars['translate'] = translate
         else:

--- a/src/grokcore/chameleon/components.py
+++ b/src/grokcore/chameleon/components.py
@@ -19,7 +19,6 @@ import sys
 import chameleon.i18n
 import martian
 import zope.i18n
-import zope.i18nmessageid
 from chameleon.tales import ExistsExpr
 from chameleon.tales import ImportExpr
 from chameleon.tales import NotExpr
@@ -67,8 +66,8 @@ class PageTemplate(PageTemplate):
                     msgid, domain=None, mapping=None, context=None,
                     target_language=None, default=None):
                 # We swap context with the request, that is required for
-                # zope.i18ntranslate.
-                if isinstance(msgid, zope.i18nmessageid.Message):
+                # zope.i18n.translate.
+                if isinstance(msgid, str):
                     return zope.i18n.translate(
                         msgid, domain, mapping, request, target_language,
                         default)

--- a/src/grokcore/chameleon/tests/cpt_fixture/app.py
+++ b/src/grokcore/chameleon/tests/cpt_fixture/app.py
@@ -68,4 +68,4 @@ class Namespace(grokcore.view.View):
 
 class Menu(grokcore.view.View):
 
-    variants = ['none']
+    variants = ['raw', 'bloody']

--- a/src/grokcore/chameleon/tests/cpt_fixture/app.py
+++ b/src/grokcore/chameleon/tests/cpt_fixture/app.py
@@ -67,4 +67,5 @@ class Namespace(grokcore.view.View):
 
 
 class Menu(grokcore.view.View):
-    pass
+
+    variants = ['none']

--- a/src/grokcore/chameleon/tests/cpt_fixture/app_templates/menu.cpt
+++ b/src/grokcore/chameleon/tests/cpt_fixture/app_templates/menu.cpt
@@ -1,9 +1,11 @@
 <html xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-    i18n:domain="grokcore-chameleon-tests">
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      i18n:domain="grokcore-chameleon-tests">
 <body>
   <h1>Menu</h1>
   <ol>
     <li i18n:translate="">Deepfried breaded veal cutlets</li>
+    <li>Variants: <tal:v i18n:translate="" tal:content="view.variants"></tal:v></li>
   </ol>
 </body>
 </html>


### PR DESCRIPTION
Only translate message ids.

Newer versions of Chameleon try to translate everything which will break later on.