### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 CHANGES
 *******
 
-4.2 (unreleased)
+5.0 (unreleased)
 ================
 
 - Drop support for Python 3.8.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ CHANGES
 5.0 (unreleased)
 ================
 
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
+
 - Drop support for Python 3.8.
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -22,7 +21,7 @@ tests_require = [
     'zope.app.appsetup',
     'zope.app.wsgi',
     'zope.testbrowser',
-    'zope.testrunner',
+    'zope.testrunner >= 6.4',
 ]
 
 
@@ -61,9 +60,6 @@ setup(
     author_email="zope-dev@zope.dev",
     url="https://github.com/zopefoundation/grokcore.chameleon/",
     license="ZPL-2.1",
-    package_dir={'': 'src'},
-    packages=find_packages('src'),
-    namespace_packages=['grokcore'],
     include_package_data=True,
     zip_safe=False,
     python_requires='>=3.9',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = '4.2.dev0'
+version = '5.0.dev0'
 
 
 install_requires = [

--- a/src/grokcore/__init__.py
+++ b/src/grokcore/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
